### PR TITLE
Fix typo in issue tracker link

### DIFF
--- a/docs/source/contribute.rst
+++ b/docs/source/contribute.rst
@@ -3,7 +3,7 @@ Contribute
 
 Thanks for considering contributing to this extension!
 
-* See the `issue tracker <https://github.com/dgarcia360/sphinx-collapse/issues>`_ for a list of features we would like to add in the future.
+* See the `issue tracker <https://github.com/dgarcia360/sphinx-contributors/issues>`_ for a list of features we would like to add in the future.
 * Feel free to propose new features or report bugs, describing how you want the extension to behave.
 * Let us know in the same issue if you want to send a pull-request ❤️
 


### PR DESCRIPTION
It was pointing to the incorrect repo.