### PR TITLE
Add Sphinx Extension classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,9 @@ home-page = "https://github.com/dgarcia360/sphinx-contributors"
 description-file = "README.rst"
 requires-python = ">=3.7"
 requires = ["sphinx >= 3"]
+classifiers=[
+  "Framework :: Sphinx :: Extension",
+]
 
 [tool.flit.metadata.requires-extra]
 test = [


### PR DESCRIPTION
Add the Sphinx Extension PyPi classifier so that the extension shows up in the correct [PyPi filters](https://pypi.org/search/?c=Framework+%3A%3A+Sphinx+%3A%3A+Extension).