### PR TITLE
Update black for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
         name: isort (python)
 
   - repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.10.0
     hooks:
       - id: black
         exclude: ^venv/


### PR DESCRIPTION
This should fix CI, as the `ImportError: cannot import name '_unicodefun' from 'click'` issue was fixed in [2.3.0](https://github.com/psf/black/releases/tag/22.3.0), but I went with a more recent stable version [2.10.0](https://github.com/psf/black/releases/tag/22.10.0).