### PR TITLE
Bump isort for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)


### PR DESCRIPTION
This should fix CI. Solution found here: https://github.com/home-assistant/core/issues/86892

Ah, it errors on Python 3.7 now. I don't think you want to run `pre-commit` on all Python versions, from my experience the `pre-commit` check comes before the environment matrix as it's own step with whatever Python version you choose (usually the latest stable version).