### PR TITLE
Add exclude option to reference.rst

### DIFF
--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -33,3 +33,10 @@ Contributors directive
       Whether to show the total number of contributions by each user or not.
 
       .. versionadded:: 0.2.3
+
+    .. rst:directive:option:: exclude
+      :type: string
+
+      Comma seperated usernames to exlude from the list of contributors, for example: ``dependabot[bot],pre-commit-ci[bot]``.
+
+      .. versionadded:: 0.2.0

--- a/docs/source/who-is-using-it.rst
+++ b/docs/source/who-is-using-it.rst
@@ -18,7 +18,7 @@ Insight Toolkit:
 meson-python:
     https://meson-python.readthedocs.io/en/latest/index.html#contributors
 MIRACL:
-    https://miracl.readthedocs.io/en/latest/about/acknowledgements.html    
+    https://miracl.readthedocs.io/en/latest/about/acknowledgements.html
 Parfive:
     https://parfive.readthedocs.io/en/stable/#contributors
 Sphinx Sitemap:

--- a/src/sphinx_contributors/__init__.py
+++ b/src/sphinx_contributors/__init__.py
@@ -76,7 +76,6 @@ class ContributorsRepository:
 
 
 class ContributorsDirective(Directive):
-
     has_content = True
     required_arguments = 1
     optional_arguments = 0
@@ -140,7 +139,7 @@ def setup(app):
     app.add_css_file("sphinx_contributors.css")
 
     return {
-        'version': __version__,
-        'parallel_read_safe': True,
-        'parallel_write_safe': True,
+        "version": __version__,
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
     }


### PR DESCRIPTION
It looks like it was added in [0.2.0](https://github.com/dgarcia360/sphinx-contributors/blob/550c3b8d9aa0be267f074b2f6abcfdfee359e9df/docs/changelog.rst#020---01-aug-2019), but was missing from the References page.

## Summary of changes

- Add exclude option to `reference.rst`
- Reformat with `black` to fix CI
- Remove trailing whitespace to fix CI